### PR TITLE
Express-session setup for persisting trims

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -2,4 +2,4 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-export const { PORT, DB_URL } = process.env;
+export const { PORT, DB_URL, SECRET_KEY } = process.env;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
+const session = require('express-session');
 const cookieParser = require('cookie-parser');
 const { PORT } = require('./config/constants');
 import { initRoutes } from './routes/routes';
@@ -20,7 +21,10 @@ app.use(express.static(path.join(__dirname, '../public')));
 
 app.use(bodyParser.json());
 app.use(cookieParser()); //Parse the cookie data (User ID).
-	
+app.use(session({
+    secret: 's3Kr3T',
+    resave: true,
+}));
 app.set('view engine', 'ejs');
 
 initRoutes(app);

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ app.use(express.static(path.join(__dirname, '../public')));
 app.use(bodyParser.json());
 app.use(cookieParser()); //Parse the cookie data (User ID).
 app.use(session({
-    secret: 's3Kr3T',
+    secret: env.SECRET_KEY,
     resave: true,
 }));
 app.set('view engine', 'ejs');

--- a/src/middlewares/cookieValidator.js
+++ b/src/middlewares/cookieValidator.js
@@ -1,0 +1,8 @@
+export const cookieValidtor = (req, res, next) => {
+  const userId = req.cookies.userID;
+  if (userId == undefined) {
+    userId = req.session.id;
+    res.cookie("userID", userId, { maxAge: 90000, httpOnly: true });
+  }
+    next();
+};

--- a/src/middlewares/middlewares.js
+++ b/src/middlewares/middlewares.js
@@ -1,4 +1,5 @@
+import {cookieValidator } from './cookieValidator';
 import { renderLandingPage } from './renderLandingPage';
 import { checkUrl } from './urlMiddleware';
 
-export { renderLandingPage, checkUrl };
+export { renderLandingPage, checkUrl, cookieValidator };

--- a/src/middlewares/renderLandingPage.js
+++ b/src/middlewares/renderLandingPage.js
@@ -9,7 +9,7 @@ import UrlShorten from '../models/UrlShorten';
  */
 export const renderLandingPage = (req, res) => {
 	UrlShorten.find({
-    created_by: req.cookies.userID //Find all clips created by this user.
+    createdBy: req.sessionID //Find all clips created by this user.
 	})
 	.then((clips) => { //Pass the user's clips to the view engine to render the customized view for this user.
 		res.render('../src/views/index', {userClips: clips});

--- a/src/middlewares/renderLandingPage.js
+++ b/src/middlewares/renderLandingPage.js
@@ -9,7 +9,7 @@ import UrlShorten from '../models/UrlShorten';
  */
 export const renderLandingPage = (req, res) => {
 	UrlShorten.find({
-    createdBy: req.sessionID //Find all clips created by this user.
+    created_by: req.cookies.userID //Find all clips created by this user.
 	})
 	.then((clips) => { //Pass the user's clips to the view engine to render the customized view for this user.
 		res.render('../src/views/index', {userClips: clips});

--- a/src/models/UrlShorten.js
+++ b/src/models/UrlShorten.js
@@ -2,10 +2,11 @@ import mongoose from "mongoose";
 const { Schema } = mongoose;
 
 const UrlShortenSchema = new Schema({
-	long_url: { type: String, required: true },
-	urlCode: { type: String, required: true },
-	createdAt: { type: Date, default: Date.now },
-	click_count: { type: Number, required: true, default: 0 }
+  long_url: { type: String, required: true },
+  urlCode: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  createdBy: { type: String, required: true },
+  click_count: { type: Number, required: true, default: 0 }
 });
 
 export default mongoose.model("UrlShorten", UrlShortenSchema);

--- a/src/models/UrlShorten.js
+++ b/src/models/UrlShorten.js
@@ -5,7 +5,7 @@ const UrlShortenSchema = new Schema({
   long_url: { type: String, required: true },
   urlCode: { type: String, required: true },
   createdAt: { type: Date, default: Date.now },
-  createdBy: { type: String, required: true },
+  created_by: { type: String, required: true },
   click_count: { type: Number, required: true, default: 0 }
 });
 

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,9 +1,9 @@
 import {respondWithWarning} from '../helpers/responseHandler';
-import { renderLandingPage, checkUrl } from "../middlewares/middlewares";
+import { renderLandingPage, checkUrl, cookieValidator } from "../middlewares/middlewares";
 import { getUrlAndUpdateCount, trimUrl, deleteUrl, redirectUrl } from '../controllers/urlController';
 
 export const initRoutes = (app) => {
-	app.get('/', renderLandingPage);
+	app.get('/', cookieValidator, renderLandingPage);
 
 	app.post('/api/trim', checkUrl, trimUrl);
 


### PR DESCRIPTION
Express-session has been set up to collect all trims saved by a particular user when the landing page loads. 
Work to be done:
1. Save the session id in database when a new URL is trimmed.